### PR TITLE
Make end of line between generated tags OS dependent

### DIFF
--- a/tasks/angular_file_loader.js
+++ b/tasks/angular_file_loader.js
@@ -11,6 +11,7 @@
 var ngDeps = require('ng-dependencies');
 var toposort = require('toposort');
 var path = require('path');
+var EOL = require('os').EOL;
 
 module.exports = function (grunt) {
 
@@ -157,9 +158,9 @@ module.exports = function (grunt) {
 
             var splitedFile = (grunt.file.read(file)).split(supportedExt[pattern]["regex"]);
 
-            splitedFile[1] = supportedExt[pattern]["comment"]["start"] + options.startTag + supportedExt[pattern]["comment"]["end"] + '\n';
+            splitedFile[1] = supportedExt[pattern]["comment"]["start"] + options.startTag + supportedExt[pattern]["comment"]["end"] + EOL;
             sortedScripts.forEach(function (script) {
-                splitedFile[1] += ((supportedExt[pattern]["recipe"]).replace('%', resolvePath(file, script))) + '\n';
+                splitedFile[1] += ((supportedExt[pattern]["recipe"]).replace('%', resolvePath(file, script))) + EOL;
             });
             splitedFile[2] = supportedExt[pattern]["comment"]["start"] + options.endTag + supportedExt[pattern]["comment"]["end"];
 


### PR DESCRIPTION
Make end of line between generated tags OS dependent. To support usemin replacement. 

Description: 
If using 'usemin' `\n` replacement of generated block is broken on Windows.
'usemin' makes suggest of [eol](https://github.com/yeoman/grunt-usemin/blob/master/lib/fileprocessor.js#L154) and then makes [string replacement](https://github.com/yeoman/grunt-usemin/blob/master/lib/fileprocessor.js#L156), which doesn't happen becouse it search string with different separator `\r\n`
