### PR TITLE
Fixed typo in #sortScripts() catch block. Line 122 changed grunt.warn…

### DIFF
--- a/tasks/angular_file_loader.js
+++ b/tasks/angular_file_loader.js
@@ -119,7 +119,7 @@ module.exports = function (grunt) {
                         files.push(file);
 
                     } catch (error) {
-                        grunt.warn.error('Error in parsing "' + file + '", ' + error.message);
+                        grunt.log.error('Error in parsing "' + file + '", ' + error.message);
                     }
                 }
             });


### PR DESCRIPTION
Fixed typo in #sortScripts() catch block. Line 122 changed grunt.warn.error to grunt.log.error
