### PR TITLE
Txt feature

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,28 +57,51 @@ module.exports = function(grunt) {
         src: ['test/fixtures/web/html/relative_string.html']
       },
       custom_tag_jade: {
-        options: {
-          startTag: 'test',
-          endTag: 'endTest'
+            options: {
+                startTag: 'test',
+                endTag: 'endTest'
+            },
+            src: ['test/fixtures/web/jade/custom_tag.jade']
         },
-        src: ['test/fixtures/web/jade/custom_tag.jade']
-      },
-      default_options_jade: {
-        options: {},
-        src: ['test/fixtures/web/jade/default_options.jade']
-      },
-      relative_false_jade: {
-        options: {
-          relative: false
+        default_options_jade: {
+            options: {},
+            src: ['test/fixtures/web/jade/default_options.jade']
         },
-        src: ['test/fixtures/web/jade/relative_false.jade']
-      },
-      relative_string_jade: {
-        options: {
-          relative: 'test/fixtures/app'
+        relative_false_jade: {
+            options: {
+                relative: false
+            },
+            src: ['test/fixtures/web/jade/relative_false.jade']
         },
-        src: ['test/fixtures/web/jade/relative_string.jade']
-      }
+        relative_string_jade: {
+            options: {
+                relative: 'test/fixtures/app'
+            },
+            src: ['test/fixtures/web/jade/relative_string.jade']
+        },
+        custom_tag_txt: {
+            options: {
+                startTag: 'test',
+                endTag: 'endTest'
+            },
+            src: ['test/fixtures/web/txt/custom_tag.txt']
+        },
+        default_options_txt: {
+            options: {},
+            src: ['test/fixtures/web/txt/default_options.txt']
+        },
+        relative_false_txt: {
+            options: {
+                relative: false
+            },
+            src: ['test/fixtures/web/txt/relative_false.txt']
+        },
+        relative_string_txt: {
+            options: {
+                relative: 'test/fixtures/app'
+            },
+            src: ['test/fixtures/web/txt/relative_string.txt']
+        }
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This plugin requires Grunt `~0.4.5`
 
 It is based on [`gulp-angular-filesort`](https://github.com/klei/gulp-angular-filesort) and [`wiredep`](https://github.com/taptapship/wiredep)
 
-It will sort and inject javascript angular files into files that you need (HTML and Jade are currently supported) 
+It will sort and inject javascript angular files into files that you need (HTML, Jade, and TXT are currently supported) 
 if some javascript files are not for angular they will be added at the end of the files list.
 
-/!\ Jade is recognised by the plugin but the injection don't handle right indent. HTML is preferred for inject
+/!\ Jade is recognised by the plugin but the injection does not handle right indent. HTML is preferred for inject
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -43,8 +43,8 @@ grunt.initConfig({
     },
     your_target: {
       src: ['index.html']
-    },
-  },
+    }
+  }
 });
 ```
 
@@ -73,6 +73,11 @@ html(lang='en')
   body
     // angular
     // endangular
+```
+
+```text
+// angular
+// endangular
 ```
 
 After task run
@@ -109,6 +114,14 @@ html(lang='en')
     script(src='...', type='text/javascript')
     // endangular
 ```
+
+```text
+// angular
+app.js
+module.js
+module-controller.js
+...
+```
 ### Options
 
 #### options.startTag
@@ -130,14 +143,14 @@ Type: `String | Array | Object`
 
 Default value: `'null'`
 
-Script Files to inject into html/jade file.
+Script Files to inject into html/jade/txt file.
 
 #### options.relative
 Type: `Boolean | String`
 
 Default value: `'true'`
 
-When set to `true` path to script files will be rewritten to be relative to html/jade file.
+When set to `true` path to script files will be rewritten to be relative to html/jade/txt file.
 When set to `false` path to script files will be rewritten to be relative to Grunfile.js
 When set to a String path to script files will be rewritten to be relative to the specified file/directory
 

--- a/tasks/angular_file_loader.js
+++ b/tasks/angular_file_loader.js
@@ -50,6 +50,14 @@ module.exports = function (grunt) {
                     start: '// ',
                     end:   ''
                 }
+            },
+            txt: {
+                recipe:  '%',
+                regex:   new RegExp('//\\s*' + options.startTag + '(\\s*)(\\n|\\r|.)*?//\\s*' + options.endTag, 'gi'),
+                comment: {
+                    start: '// ',
+                    end:   ''
+                }
             }
         };
 

--- a/test/angular_filesort_test.js
+++ b/test/angular_filesort_test.js
@@ -111,5 +111,48 @@ exports.angularFileLoader = {
     test.equal(actual, expected, 'Injection must be done');
 
     test.done();
+  },
+
+  custom_tag_txt: function(test) {
+      test.expect(1);
+
+      var actual = grunt.file.read('test/fixtures/web/txt/custom_tag.txt');
+      var expected = grunt.file.read('test/expected/txt/custom_tag.txt');
+      test.equal(actual, expected, 'Injection must be done');
+
+      test.done();
+  },
+
+  default_options_txt: function(test) {
+      test.expect(1);
+
+      var actual = grunt.file.read('test/fixtures/web/txt/default_options.txt');
+      var expected = grunt.file.read('test/expected/txt/default_options.txt');
+
+      test.equal(actual, expected, 'Injection must be done');
+
+      test.done();
+  },
+
+  relative_false_txt: function(test) {
+      test.expect(1);
+
+      var actual = grunt.file.read('test/fixtures/web/txt/relative_false.txt');
+      var expected = grunt.file.read('test/expected/txt/relative_false.txt');
+
+      test.equal(actual, expected, 'Injection must be done');
+
+      test.done();
+  },
+
+  relative_string_txt: function(test) {
+      test.expect(1);
+
+      var actual = grunt.file.read('test/fixtures/web/txt/relative_string.txt');
+      var expected = grunt.file.read('test/expected/txt/relative_string.txt');
+
+      test.equal(actual, expected, 'Injection must be done');
+
+      test.done();
   }
 };

--- a/test/expected/txt/custom_tag.txt
+++ b/test/expected/txt/custom_tag.txt
@@ -1,0 +1,12 @@
+// test
+../../app/scripts/another.js
+../../app/scripts/yet-another.js
+../../app/scripts/no-deps.js
+../../app/scripts/module.js
+../../app/scripts/module-controller.js
+../../app/scripts/dep-on-non-declared.js
+../../app/scripts/circular3.js
+../../app/scripts/circular2.js
+../../app/scripts/circular.js
+../../app/scripts/another-factory.js
+// endTest

--- a/test/expected/txt/default_options.txt
+++ b/test/expected/txt/default_options.txt
@@ -1,0 +1,12 @@
+// angular
+../../app/scripts/another.js
+../../app/scripts/yet-another.js
+../../app/scripts/no-deps.js
+../../app/scripts/module.js
+../../app/scripts/module-controller.js
+../../app/scripts/dep-on-non-declared.js
+../../app/scripts/circular3.js
+../../app/scripts/circular2.js
+../../app/scripts/circular.js
+../../app/scripts/another-factory.js
+// endangular

--- a/test/expected/txt/relative_false.txt
+++ b/test/expected/txt/relative_false.txt
@@ -1,0 +1,12 @@
+// angular
+test/fixtures/app/scripts/another.js
+test/fixtures/app/scripts/yet-another.js
+test/fixtures/app/scripts/no-deps.js
+test/fixtures/app/scripts/module.js
+test/fixtures/app/scripts/module-controller.js
+test/fixtures/app/scripts/dep-on-non-declared.js
+test/fixtures/app/scripts/circular3.js
+test/fixtures/app/scripts/circular2.js
+test/fixtures/app/scripts/circular.js
+test/fixtures/app/scripts/another-factory.js
+// endangular

--- a/test/expected/txt/relative_string.txt
+++ b/test/expected/txt/relative_string.txt
@@ -1,0 +1,12 @@
+// angular
+app/scripts/another.js
+app/scripts/yet-another.js
+app/scripts/no-deps.js
+app/scripts/module.js
+app/scripts/module-controller.js
+app/scripts/dep-on-non-declared.js
+app/scripts/circular3.js
+app/scripts/circular2.js
+app/scripts/circular.js
+app/scripts/another-factory.js
+// endangular

--- a/test/fixtures/web/txt/custom_tag.txt
+++ b/test/fixtures/web/txt/custom_tag.txt
@@ -1,0 +1,12 @@
+// test
+../../app/scripts/another.js
+../../app/scripts/yet-another.js
+../../app/scripts/no-deps.js
+../../app/scripts/module.js
+../../app/scripts/module-controller.js
+../../app/scripts/dep-on-non-declared.js
+../../app/scripts/circular3.js
+../../app/scripts/circular2.js
+../../app/scripts/circular.js
+../../app/scripts/another-factory.js
+// endTest

--- a/test/fixtures/web/txt/default_options.txt
+++ b/test/fixtures/web/txt/default_options.txt
@@ -1,0 +1,12 @@
+// angular
+../../app/scripts/another.js
+../../app/scripts/yet-another.js
+../../app/scripts/no-deps.js
+../../app/scripts/module.js
+../../app/scripts/module-controller.js
+../../app/scripts/dep-on-non-declared.js
+../../app/scripts/circular3.js
+../../app/scripts/circular2.js
+../../app/scripts/circular.js
+../../app/scripts/another-factory.js
+// endangular

--- a/test/fixtures/web/txt/relative_false.txt
+++ b/test/fixtures/web/txt/relative_false.txt
@@ -1,0 +1,12 @@
+// angular
+test/fixtures/app/scripts/another.js
+test/fixtures/app/scripts/yet-another.js
+test/fixtures/app/scripts/no-deps.js
+test/fixtures/app/scripts/module.js
+test/fixtures/app/scripts/module-controller.js
+test/fixtures/app/scripts/dep-on-non-declared.js
+test/fixtures/app/scripts/circular3.js
+test/fixtures/app/scripts/circular2.js
+test/fixtures/app/scripts/circular.js
+test/fixtures/app/scripts/another-factory.js
+// endangular

--- a/test/fixtures/web/txt/relative_string.txt
+++ b/test/fixtures/web/txt/relative_string.txt
@@ -1,0 +1,12 @@
+// angular
+app/scripts/another.js
+app/scripts/yet-another.js
+app/scripts/no-deps.js
+app/scripts/module.js
+app/scripts/module-controller.js
+app/scripts/dep-on-non-declared.js
+app/scripts/circular3.js
+app/scripts/circular2.js
+app/scripts/circular.js
+app/scripts/another-factory.js
+// endangular


### PR DESCRIPTION
Adds plain txt file output.  This was added due to need for sorted globbing prior to minification.  A raw glob is split into an array of path strings and is passed to the scripts of angularFileLoader task:
```
var myApp_pattern = "src/main/webapp/myApp/components/**/*.js";
var myApp_files = glob.sync(myApp_pattern);
```
...
```
angularFileLoader: {
                options: {
                    scripts: myApp_files,
                    relative: false
                },
                your_target: {
                    src: ['src/main/webapp/myApp/components/myApp_imports.txt']
                }
            },
```
The txt file is used as a minification src, e.g:
```
function sortPathsToArray() {
            var buffer = grunt.file.read('src/main/webapp/myApp/components/myApp_imports.txt');
            var pathString = buffer.toString();
            var myApp_files_sorted = pathString.split('\n');
            // remove the start/end tags
            myApp_files_sorted.pop();
            myApp_files_sorted.shift();

            return myApp_files_sorted;
        }
```
Then, in uglify:
```
uglify: {
                options: {
                    banner: '/*! <%= pkg.name %> <%= grunt.template.today("yyyy-mm-dd") %> */\n',
                    mangle: false,
                    compress: false,
                    verbose: true
                },
                dist: {
                    files: {
                       'src/main/webapp/myApp/components/myApp.min.js': sortPathsToArray()
                    }
                }
            },
```